### PR TITLE
Update Nexus version and dependencies in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.github.flytreeleft</groupId>
     <artifactId>nexus3-keycloak-plugin</artifactId>
-    <version>0.8.9-0</version>
+    <version>0.8.10-0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>bundle</packaging>
 
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.sonatype.nexus.plugins</groupId>
         <artifactId>nexus-plugins</artifactId>
-        <version>3.71.0-06</version>
+        <version>3.77.2-02</version>
     </parent>
 
     <properties>
@@ -95,6 +95,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <version>${keycloak.version}</version>
@@ -119,6 +124,11 @@
             <artifactId>goodies-testsupport</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+            <version>1.2</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -130,7 +140,19 @@
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
                 </configuration>
-            </plugin>
+			<dependencies>
+					<dependency>
+						<groupId>org.codehaus.groovy</groupId>
+						<artifactId>groovy-eclipse-compiler</artifactId>
+						<version>3.7.0</version>
+					</dependency>
+					<dependency>
+						<groupId>org.codehaus.groovy</groupId>
+						<artifactId>groovy-eclipse-batch</artifactId>
+						<version>3.0.8-01</version>
+					</dependency>
+				</dependencies>
+			</plugin>
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
@@ -151,7 +173,10 @@
                         </Import-Package>
                         <!-- Package all specified class into bundle jar. -->
                         <Export-Package>
-                            org.keycloak.*
+                            org.keycloak.*,
+                            jakarta.activation.*,
+                            com.sun.activation.*,
+                            org.eclipse.microprofile.openapi.*
                         </Export-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
Upgrade the plugin version from 0.8.9-0 to 0.8.10-0.
Upgrade the Nexus parent version from 3.71.0-06 to 3.77.2-02.

Add new dependencies:

-   jakarta.activation (version 2.0.1)
-  microprofile-openapi-api (version 1.2)
-  groovy-eclipse-compiler (version 3.7.0)
-  groovy-eclipse-batch (version 3.0.8-01)

Update the Export-Package section to include:

-  jakarta.activation.*
-  com.sun.activation.*
-  org.eclipse.microprofile.openapi.*

These changes ensure compatibility with the latest Nexus version.